### PR TITLE
Correct includes value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Allows an user to dynamically add and remove saved WiFi APs.
 paragraph=When the device cannot connect to any saved WiFi networks, it will launch its own access point for a user to add a WiFi network.
 category=Communication
 url=https://github.com/Tvde1/esp8266-wifi-picker
-includes=FS.h,ESP8266WiFi.h,WiFiClient.h,DNSServer.h,map
+includes=WiFiPicker.h


### PR DESCRIPTION
The `includes` field in library.properties is used to customize which `#include` directives will be added to the sketch by the Arduino IDE via **Sketch > Include Library > esp8266-wifi-picker**. For this reason, the previous `includes` value was incorrect.

The `includes` field is only supported by Arduino IDE 1.6.10 and newer and those IDE versions do not require you to add `#include` directives for library dependencies so there is no need to have `FS.h,ESP8266WiFi.h,WiFiClient.h,DNSServer.h,map` in the `includes` field.

What is needed in the `include`s field is WiFiPicker.h, which I have added in lieu of the unnecessary file names.